### PR TITLE
feat: render villages and castles; switch map glyphs to unicode

### DIFF
--- a/internal/proto/gongeons.pb.go
+++ b/internal/proto/gongeons.pb.go
@@ -166,6 +166,57 @@ func (OccupantKind) EnumDescriptor() ([]byte, []int) {
 	return file_gongeons_proto_rawDescGZIP(), []int{1}
 }
 
+// WorldObject is a static structure the procedural generator places on a tile.
+// Rendered below the player glyph but above the terrain.
+type WorldObject int32
+
+const (
+	WorldObject_WORLD_OBJECT_UNSPECIFIED WorldObject = 0
+	WorldObject_WORLD_OBJECT_VILLAGE     WorldObject = 1
+	WorldObject_WORLD_OBJECT_CASTLE      WorldObject = 2
+)
+
+// Enum value maps for WorldObject.
+var (
+	WorldObject_name = map[int32]string{
+		0: "WORLD_OBJECT_UNSPECIFIED",
+		1: "WORLD_OBJECT_VILLAGE",
+		2: "WORLD_OBJECT_CASTLE",
+	}
+	WorldObject_value = map[string]int32{
+		"WORLD_OBJECT_UNSPECIFIED": 0,
+		"WORLD_OBJECT_VILLAGE":     1,
+		"WORLD_OBJECT_CASTLE":      2,
+	}
+)
+
+func (x WorldObject) Enum() *WorldObject {
+	p := new(WorldObject)
+	*p = x
+	return p
+}
+
+func (x WorldObject) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (WorldObject) Descriptor() protoreflect.EnumDescriptor {
+	return file_gongeons_proto_enumTypes[2].Descriptor()
+}
+
+func (WorldObject) Type() protoreflect.EnumType {
+	return &file_gongeons_proto_enumTypes[2]
+}
+
+func (x WorldObject) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use WorldObject.Descriptor instead.
+func (WorldObject) EnumDescriptor() ([]byte, []int) {
+	return file_gongeons_proto_rawDescGZIP(), []int{2}
+}
+
 // Position is an absolute square-grid tile coordinate. Origin is arbitrary
 // (world 0, 0); the coordinate system is unbounded in both axes.
 type Position struct {
@@ -226,8 +277,9 @@ type Tile struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Terrain       Terrain                `protobuf:"varint,1,opt,name=terrain,proto3,enum=gongeons.v1.Terrain" json:"terrain,omitempty"`
 	Occupant      OccupantKind           `protobuf:"varint,2,opt,name=occupant,proto3,enum=gongeons.v1.OccupantKind" json:"occupant,omitempty"`
-	EntityId      string                 `protobuf:"bytes,3,opt,name=entity_id,json=entityId,proto3" json:"entity_id,omitempty"` // occupant ID, empty if no occupant
-	River         bool                   `protobuf:"varint,4,opt,name=river,proto3" json:"river,omitempty"`                      // set on tiles the generator carved a river on
+	EntityId      string                 `protobuf:"bytes,3,opt,name=entity_id,json=entityId,proto3" json:"entity_id,omitempty"`           // occupant ID, empty if no occupant
+	River         bool                   `protobuf:"varint,4,opt,name=river,proto3" json:"river,omitempty"`                                // set on tiles the generator carved a river on
+	Object        WorldObject            `protobuf:"varint,5,opt,name=object,proto3,enum=gongeons.v1.WorldObject" json:"object,omitempty"` // village / castle overlay
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -288,6 +340,13 @@ func (x *Tile) GetRiver() bool {
 		return x.River
 	}
 	return false
+}
+
+func (x *Tile) GetObject() WorldObject {
+	if x != nil {
+		return x.Object
+	}
+	return WorldObject_WORLD_OBJECT_UNSPECIFIED
 }
 
 // Entity is a positioned actor in the world. Combat stats / monsters are
@@ -1186,12 +1245,13 @@ const file_gongeons_proto_rawDesc = "" +
 	"\x0egongeons.proto\x12\vgongeons.v1\"&\n" +
 	"\bPosition\x12\f\n" +
 	"\x01x\x18\x01 \x01(\x05R\x01x\x12\f\n" +
-	"\x01y\x18\x02 \x01(\x05R\x01y\"\xa0\x01\n" +
+	"\x01y\x18\x02 \x01(\x05R\x01y\"\xd2\x01\n" +
 	"\x04Tile\x12.\n" +
 	"\aterrain\x18\x01 \x01(\x0e2\x14.gongeons.v1.TerrainR\aterrain\x125\n" +
 	"\boccupant\x18\x02 \x01(\x0e2\x19.gongeons.v1.OccupantKindR\boccupant\x12\x1b\n" +
 	"\tentity_id\x18\x03 \x01(\tR\bentityId\x12\x14\n" +
-	"\x05river\x18\x04 \x01(\bR\x05river\"\x8e\x01\n" +
+	"\x05river\x18\x04 \x01(\bR\x05river\x120\n" +
+	"\x06object\x18\x05 \x01(\x0e2\x18.gongeons.v1.WorldObjectR\x06object\"\x8e\x01\n" +
 	"\x06Entity\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12-\n" +
@@ -1267,7 +1327,11 @@ const file_gongeons_proto_rawDesc = "" +
 	"\fOccupantKind\x12\x18\n" +
 	"\x14OCCUPANT_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fOCCUPANT_PLAYER\x10\x01\x12\x14\n" +
-	"\x10OCCUPANT_MONSTER\x10\x022Q\n" +
+	"\x10OCCUPANT_MONSTER\x10\x02*^\n" +
+	"\vWorldObject\x12\x1c\n" +
+	"\x18WORLD_OBJECT_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14WORLD_OBJECT_VILLAGE\x10\x01\x12\x17\n" +
+	"\x13WORLD_OBJECT_CASTLE\x10\x022Q\n" +
 	"\vGameService\x12B\n" +
 	"\x04Play\x12\x1a.gongeons.v1.ClientMessage\x1a\x1a.gongeons.v1.ServerMessage(\x010\x01B8Z6github.com/Rioverde/gongeons/internal/proto;gongeonspbb\x06proto3"
 
@@ -1283,56 +1347,58 @@ func file_gongeons_proto_rawDescGZIP() []byte {
 	return file_gongeons_proto_rawDescData
 }
 
-var file_gongeons_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_gongeons_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_gongeons_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_gongeons_proto_goTypes = []any{
 	(Terrain)(0),          // 0: gongeons.v1.Terrain
 	(OccupantKind)(0),     // 1: gongeons.v1.OccupantKind
-	(*Position)(nil),      // 2: gongeons.v1.Position
-	(*Tile)(nil),          // 3: gongeons.v1.Tile
-	(*Entity)(nil),        // 4: gongeons.v1.Entity
-	(*ClientMessage)(nil), // 5: gongeons.v1.ClientMessage
-	(*JoinRequest)(nil),   // 6: gongeons.v1.JoinRequest
-	(*ViewportCmd)(nil),   // 7: gongeons.v1.ViewportCmd
-	(*MoveCmd)(nil),       // 8: gongeons.v1.MoveCmd
-	(*ServerMessage)(nil), // 9: gongeons.v1.ServerMessage
-	(*JoinAccepted)(nil),  // 10: gongeons.v1.JoinAccepted
-	(*Snapshot)(nil),      // 11: gongeons.v1.Snapshot
-	(*Event)(nil),         // 12: gongeons.v1.Event
-	(*PlayerJoined)(nil),  // 13: gongeons.v1.PlayerJoined
-	(*PlayerLeft)(nil),    // 14: gongeons.v1.PlayerLeft
-	(*EntityMoved)(nil),   // 15: gongeons.v1.EntityMoved
-	(*ErrorResponse)(nil), // 16: gongeons.v1.ErrorResponse
+	(WorldObject)(0),      // 2: gongeons.v1.WorldObject
+	(*Position)(nil),      // 3: gongeons.v1.Position
+	(*Tile)(nil),          // 4: gongeons.v1.Tile
+	(*Entity)(nil),        // 5: gongeons.v1.Entity
+	(*ClientMessage)(nil), // 6: gongeons.v1.ClientMessage
+	(*JoinRequest)(nil),   // 7: gongeons.v1.JoinRequest
+	(*ViewportCmd)(nil),   // 8: gongeons.v1.ViewportCmd
+	(*MoveCmd)(nil),       // 9: gongeons.v1.MoveCmd
+	(*ServerMessage)(nil), // 10: gongeons.v1.ServerMessage
+	(*JoinAccepted)(nil),  // 11: gongeons.v1.JoinAccepted
+	(*Snapshot)(nil),      // 12: gongeons.v1.Snapshot
+	(*Event)(nil),         // 13: gongeons.v1.Event
+	(*PlayerJoined)(nil),  // 14: gongeons.v1.PlayerJoined
+	(*PlayerLeft)(nil),    // 15: gongeons.v1.PlayerLeft
+	(*EntityMoved)(nil),   // 16: gongeons.v1.EntityMoved
+	(*ErrorResponse)(nil), // 17: gongeons.v1.ErrorResponse
 }
 var file_gongeons_proto_depIdxs = []int32{
 	0,  // 0: gongeons.v1.Tile.terrain:type_name -> gongeons.v1.Terrain
 	1,  // 1: gongeons.v1.Tile.occupant:type_name -> gongeons.v1.OccupantKind
-	1,  // 2: gongeons.v1.Entity.kind:type_name -> gongeons.v1.OccupantKind
-	2,  // 3: gongeons.v1.Entity.position:type_name -> gongeons.v1.Position
-	6,  // 4: gongeons.v1.ClientMessage.join:type_name -> gongeons.v1.JoinRequest
-	8,  // 5: gongeons.v1.ClientMessage.move:type_name -> gongeons.v1.MoveCmd
-	7,  // 6: gongeons.v1.ClientMessage.viewport:type_name -> gongeons.v1.ViewportCmd
-	10, // 7: gongeons.v1.ServerMessage.accepted:type_name -> gongeons.v1.JoinAccepted
-	11, // 8: gongeons.v1.ServerMessage.snapshot:type_name -> gongeons.v1.Snapshot
-	12, // 9: gongeons.v1.ServerMessage.event:type_name -> gongeons.v1.Event
-	16, // 10: gongeons.v1.ServerMessage.error:type_name -> gongeons.v1.ErrorResponse
-	2,  // 11: gongeons.v1.JoinAccepted.spawn:type_name -> gongeons.v1.Position
-	2,  // 12: gongeons.v1.Snapshot.origin:type_name -> gongeons.v1.Position
-	3,  // 13: gongeons.v1.Snapshot.tiles:type_name -> gongeons.v1.Tile
-	4,  // 14: gongeons.v1.Snapshot.entities:type_name -> gongeons.v1.Entity
-	13, // 15: gongeons.v1.Event.player_joined:type_name -> gongeons.v1.PlayerJoined
-	14, // 16: gongeons.v1.Event.player_left:type_name -> gongeons.v1.PlayerLeft
-	15, // 17: gongeons.v1.Event.entity_moved:type_name -> gongeons.v1.EntityMoved
-	4,  // 18: gongeons.v1.PlayerJoined.entity:type_name -> gongeons.v1.Entity
-	2,  // 19: gongeons.v1.EntityMoved.from:type_name -> gongeons.v1.Position
-	2,  // 20: gongeons.v1.EntityMoved.to:type_name -> gongeons.v1.Position
-	5,  // 21: gongeons.v1.GameService.Play:input_type -> gongeons.v1.ClientMessage
-	9,  // 22: gongeons.v1.GameService.Play:output_type -> gongeons.v1.ServerMessage
-	22, // [22:23] is the sub-list for method output_type
-	21, // [21:22] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	2,  // 2: gongeons.v1.Tile.object:type_name -> gongeons.v1.WorldObject
+	1,  // 3: gongeons.v1.Entity.kind:type_name -> gongeons.v1.OccupantKind
+	3,  // 4: gongeons.v1.Entity.position:type_name -> gongeons.v1.Position
+	7,  // 5: gongeons.v1.ClientMessage.join:type_name -> gongeons.v1.JoinRequest
+	9,  // 6: gongeons.v1.ClientMessage.move:type_name -> gongeons.v1.MoveCmd
+	8,  // 7: gongeons.v1.ClientMessage.viewport:type_name -> gongeons.v1.ViewportCmd
+	11, // 8: gongeons.v1.ServerMessage.accepted:type_name -> gongeons.v1.JoinAccepted
+	12, // 9: gongeons.v1.ServerMessage.snapshot:type_name -> gongeons.v1.Snapshot
+	13, // 10: gongeons.v1.ServerMessage.event:type_name -> gongeons.v1.Event
+	17, // 11: gongeons.v1.ServerMessage.error:type_name -> gongeons.v1.ErrorResponse
+	3,  // 12: gongeons.v1.JoinAccepted.spawn:type_name -> gongeons.v1.Position
+	3,  // 13: gongeons.v1.Snapshot.origin:type_name -> gongeons.v1.Position
+	4,  // 14: gongeons.v1.Snapshot.tiles:type_name -> gongeons.v1.Tile
+	5,  // 15: gongeons.v1.Snapshot.entities:type_name -> gongeons.v1.Entity
+	14, // 16: gongeons.v1.Event.player_joined:type_name -> gongeons.v1.PlayerJoined
+	15, // 17: gongeons.v1.Event.player_left:type_name -> gongeons.v1.PlayerLeft
+	16, // 18: gongeons.v1.Event.entity_moved:type_name -> gongeons.v1.EntityMoved
+	5,  // 19: gongeons.v1.PlayerJoined.entity:type_name -> gongeons.v1.Entity
+	3,  // 20: gongeons.v1.EntityMoved.from:type_name -> gongeons.v1.Position
+	3,  // 21: gongeons.v1.EntityMoved.to:type_name -> gongeons.v1.Position
+	6,  // 22: gongeons.v1.GameService.Play:input_type -> gongeons.v1.ClientMessage
+	10, // 23: gongeons.v1.GameService.Play:output_type -> gongeons.v1.ServerMessage
+	23, // [23:24] is the sub-list for method output_type
+	22, // [22:23] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_gongeons_proto_init() }
@@ -1361,7 +1427,7 @@ func file_gongeons_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_gongeons_proto_rawDesc), len(file_gongeons_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      3,
 			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/internal/server/mapper.go
+++ b/internal/server/mapper.go
@@ -89,6 +89,22 @@ func positionPB(p game.Position) *pb.Position {
 	return &pb.Position{X: int32(p.X), Y: int32(p.Y)}
 }
 
+// objectPBMapping translates the domain ObjectKind enum to its wire
+// counterpart. Unknown values fall back to UNSPECIFIED.
+var objectPBMapping = map[game.ObjectKind]pb.WorldObject{
+	game.ObjectVillage: pb.WorldObject_WORLD_OBJECT_VILLAGE,
+	game.ObjectCastle:  pb.WorldObject_WORLD_OBJECT_CASTLE,
+}
+
+// objectToPB looks up k in objectPBMapping. ObjectNone maps implicitly to
+// UNSPECIFIED via the default return.
+func objectToPB(k game.ObjectKind) pb.WorldObject {
+	if v, ok := objectPBMapping[k]; ok {
+		return v
+	}
+	return pb.WorldObject_WORLD_OBJECT_UNSPECIFIED
+}
+
 // terrainPBMapping is the 1:1 translation table from the domain Terrain
 // enum to its wire counterpart. Kept as a map (not a switch) so adding a
 // new biome is a single-line change and cyclomatic complexity stays flat.
@@ -155,6 +171,7 @@ func snapshotOf(w *game.World, center game.Position, viewW, viewH int) *pb.Snaps
 			out := &pb.Tile{
 				Terrain: terrainToPB(t.Terrain),
 				River:   t.River,
+				Object:  objectToPB(t.Object),
 			}
 			if pl, ok := t.Occupant.(*game.Player); ok && pl != nil {
 				out.Occupant = pb.OccupantKind_OCCUPANT_PLAYER

--- a/internal/server/mapper_test.go
+++ b/internal/server/mapper_test.go
@@ -112,6 +112,56 @@ func TestTerrainToPBMapping(t *testing.T) {
 	}
 }
 
+func TestObjectToPBMapping(t *testing.T) {
+	cases := map[game.ObjectKind]pb.WorldObject{
+		game.ObjectVillage:     pb.WorldObject_WORLD_OBJECT_VILLAGE,
+		game.ObjectCastle:      pb.WorldObject_WORLD_OBJECT_CASTLE,
+		game.ObjectNone:        pb.WorldObject_WORLD_OBJECT_UNSPECIFIED,
+		game.ObjectKind("xyz"): pb.WorldObject_WORLD_OBJECT_UNSPECIFIED,
+	}
+	for in, want := range cases {
+		if got := objectToPB(in); got != want {
+			t.Errorf("objectToPB(%q): want %v, got %v", string(in), want, got)
+		}
+	}
+}
+
+// villageTileSource is a TileSource that paints a village over plains at a
+// fixed target coordinate and plain plains everywhere else. Used by
+// TestSnapshotOfIncludesObjects to assert the wire Snapshot carries the
+// object field through.
+type villageTileSource struct {
+	target game.Position
+}
+
+func (s villageTileSource) TileAt(x, y int) game.Tile {
+	if (game.Position{X: x, Y: y}) == s.target {
+		return game.Tile{Terrain: game.TerrainPlains, Object: game.ObjectVillage}
+	}
+	return game.Tile{Terrain: game.TerrainPlains}
+}
+
+func TestSnapshotOfIncludesObjects(t *testing.T) {
+	target := game.Position{X: 3, Y: 4}
+	w := game.NewWorldFromSource(villageTileSource{target: target})
+
+	// Centre the viewport on the target so the local index is trivially
+	// computable from the viewport dimensions.
+	snap := snapshotOf(w, target, DefaultViewportWidth, DefaultViewportHeight)
+	localX := int(snap.GetWidth()) / 2
+	localY := int(snap.GetHeight()) / 2
+	idx := localY*int(snap.GetWidth()) + localX
+
+	tiles := snap.GetTiles()
+	if idx >= len(tiles) {
+		t.Fatalf("target index %d out of range (%d tiles)", idx, len(tiles))
+	}
+	if got := tiles[idx].GetObject(); got != pb.WorldObject_WORLD_OBJECT_VILLAGE {
+		t.Fatalf("centre tile object = %v, want %v",
+			got, pb.WorldObject_WORLD_OBJECT_VILLAGE)
+	}
+}
+
 func TestSnapshotOfShape(t *testing.T) {
 	w := game.NewWorld(42)
 	events, err := w.ApplyCommand(game.JoinCmd{PlayerID: "p1", Name: "alice"})

--- a/internal/ui/mapper_test.go
+++ b/internal/ui/mapper_test.go
@@ -188,17 +188,17 @@ func TestLookTileKnownAndUnknown(t *testing.T) {
 	t.Parallel()
 	known := &pb.Tile{Terrain: pb.Terrain_TERRAIN_FOREST}
 	r, _ := lookTile(known)
-	if r == RuneUnspecified {
+	if r == runeUnspecified {
 		t.Fatalf("lookTile(known biome) returned unspecified rune")
 	}
 	unknown := &pb.Tile{Terrain: pb.Terrain(999)}
 	r, _ = lookTile(unknown)
-	if r != RuneUnspecified {
-		t.Fatalf("lookTile(unknown) = %q, want %q", r, RuneUnspecified)
+	if r != runeUnspecified {
+		t.Fatalf("lookTile(unknown) = %q, want %q", r, runeUnspecified)
 	}
 	river := &pb.Tile{Terrain: pb.Terrain_TERRAIN_FOREST, River: true}
 	r, _ = lookTile(river)
-	if r != RiverRune {
-		t.Fatalf("lookTile(river) = %q, want %q", r, RiverRune)
+	if r != riverRune {
+		t.Fatalf("lookTile(river) = %q, want %q", r, riverRune)
 	}
 }

--- a/internal/ui/runes.go
+++ b/internal/ui/runes.go
@@ -4,27 +4,69 @@ import pb "github.com/Rioverde/gongeons/internal/proto"
 
 // This file is the single source of truth for every glyph that reaches the
 // screen. Colours live in styles.go; rune choice lives here so you can
-// rebalance the visual vocabulary (swap to Unicode block characters, or to
-// a fantasy-roguelike alternative set) without touching anything else.
+// rebalance the visual vocabulary without touching anything else.
+//
+// Everything below is a single display-cell wide in well-behaved terminals.
+// If a glyph renders as double-width (most commonly emoji variants with the
+// VS16 selector), the grid will visually skew — swap to a narrower one.
 
 // Occupant overlay runes. Occupants win over terrain when a tile is
 // rendered — they sit "on top of" the biome glyph.
 const (
-	RuneSelf        = "@"
-	RuneOther       = "P"
+	RuneSelf        = "@" // classic roguelike player — universal, unambiguous
+	RuneOther       = "𐙬" // hanja-ish "person", single-width in most monospace
 	RuneUnspecified = "?"
 )
 
 // RiverRune is painted on tiles the procedural generator marked as part of
 // a river. It sits over the underlying biome.
-const RiverRune = "~"
+const RiverRune = "≈"
+
+// ObjectRunes maps village / castle / etc. to the glyph drawn in place of
+// the terrain rune. Rendered below players but above rivers and terrain.
+var ObjectRunes = map[pb.WorldObject]string{
+	pb.WorldObject_WORLD_OBJECT_VILLAGE: "⌂", // BMP U+2302 HOUSE
+	pb.WorldObject_WORLD_OBJECT_CASTLE:  "♜", // BMP U+265C BLACK CHESS ROOK
+}
+
+// TerrainRunes maps every wire-level Terrain value to the rune shown for
+// that biome. Missing keys fall back to RuneUnspecified in the renderer.
+var TerrainRunes = map[pb.Terrain]string{
+	// Grass family: progressively denser vegetation.
+	pb.Terrain_TERRAIN_PLAINS:    "·", // middle dot
+	pb.Terrain_TERRAIN_GRASSLAND: "„", // low double comma
+	pb.Terrain_TERRAIN_MEADOW:    "❀", // flower
+
+	// Arid family: grainy textures, beach → dune.
+	pb.Terrain_TERRAIN_BEACH:   "░", // light shade
+	pb.Terrain_TERRAIN_SAVANNA: "⁖", // four-dot cluster
+	pb.Terrain_TERRAIN_DESERT:  "∙", // bullet operator
+
+	// Forest family: deciduous / tangled / conifer.
+	pb.Terrain_TERRAIN_FOREST: "♣", // club (canopy)
+	pb.Terrain_TERRAIN_JUNGLE: "♠", // spade (denser canopy)
+	pb.Terrain_TERRAIN_TAIGA:  "♤", // white spade (conifer)
+
+	// Cold flats.
+	pb.Terrain_TERRAIN_TUNDRA: "‥", // two-dot leader (sparse)
+	pb.Terrain_TERRAIN_SNOW:   "∗", // asterisk operator (non-emoji, narrow)
+
+	// Relief ladder: bump → peak → snow-capped peak.
+	pb.Terrain_TERRAIN_HILLS:      "∩", // inverted cup
+	pb.Terrain_TERRAIN_MOUNTAIN:   "▲", // solid up-triangle
+	pb.Terrain_TERRAIN_SNOWY_PEAK: "△", // hollow up-triangle
+
+	// Water: wave → heavy wave.
+	pb.Terrain_TERRAIN_OCEAN:      "≈", // approximately equal (wavelets)
+	pb.Terrain_TERRAIN_DEEP_OCEAN: "≋", // triple tilde (deeper)
+}
 
 // UI chrome runes — every string literal that shows up outside the map
 // grid. Centralised here so a redesign touches one file.
 const (
-	InputPrompt    = "> "
-	LogBullet      = "*"
-	StatusDivider  = "  |  "
+	InputPrompt    = "❯ "
+	LogBullet      = "•"
+	StatusDivider  = "  │  "
 	EmptyLogLabel  = "(quiet)"
 	EmptyMapLabel  = "(no map yet)"
 	EmptyListLabel = "(none)"
@@ -35,35 +77,3 @@ const (
 	TitleText      = "Gongeons"
 	DisconnectHint = "press q to quit"
 )
-
-// TerrainRunes maps every wire-level Terrain value to the rune shown for
-// that biome. Missing keys fall back to RuneUnspecified in the renderer.
-var TerrainRunes = map[pb.Terrain]string{
-	// Grass family: rune weight grows with vegetation density.
-	pb.Terrain_TERRAIN_PLAINS:    ".",
-	pb.Terrain_TERRAIN_GRASSLAND: ",",
-	pb.Terrain_TERRAIN_MEADOW:    "\"",
-
-	// Arid family: grainy punctuation, beach to dune horizon.
-	pb.Terrain_TERRAIN_BEACH:   ":",
-	pb.Terrain_TERRAIN_SAVANNA: ";",
-	pb.Terrain_TERRAIN_DESERT:  "-",
-
-	// Forest family: deciduous / tangled canopy / conifer.
-	pb.Terrain_TERRAIN_FOREST: "T",
-	pb.Terrain_TERRAIN_JUNGLE: "&",
-	pb.Terrain_TERRAIN_TAIGA:  "Y",
-
-	// Cold flats.
-	pb.Terrain_TERRAIN_TUNDRA: "'",
-	pb.Terrain_TERRAIN_SNOW:   "*",
-
-	// Relief ladder: bump -> peak -> snow-capped peak.
-	pb.Terrain_TERRAIN_HILLS:      "n",
-	pb.Terrain_TERRAIN_MOUNTAIN:   "^",
-	pb.Terrain_TERRAIN_SNOWY_PEAK: "A",
-
-	// Water: wave -> flat depth.
-	pb.Terrain_TERRAIN_OCEAN:      "~",
-	pb.Terrain_TERRAIN_DEEP_OCEAN: "=",
-}

--- a/internal/ui/runes.go
+++ b/internal/ui/runes.go
@@ -13,25 +13,25 @@ import pb "github.com/Rioverde/gongeons/internal/proto"
 // Occupant overlay runes. Occupants win over terrain when a tile is
 // rendered — they sit "on top of" the biome glyph.
 const (
-	RuneSelf        = "@" // classic roguelike player — universal, unambiguous
-	RuneOther       = "𐙬" // hanja-ish "person", single-width in most monospace
-	RuneUnspecified = "?"
+	runeSelf        = "@" // classic roguelike player — universal, unambiguous
+	runeOther       = "♟" // BMP U+265F BLACK CHESS PAWN, single-cell, pairs with castle rook
+	runeUnspecified = "?"
 )
 
-// RiverRune is painted on tiles the procedural generator marked as part of
+// riverRune is painted on tiles the procedural generator marked as part of
 // a river. It sits over the underlying biome.
-const RiverRune = "≈"
+const riverRune = "≈"
 
-// ObjectRunes maps village / castle / etc. to the glyph drawn in place of
+// objectRunes maps village / castle / etc. to the glyph drawn in place of
 // the terrain rune. Rendered below players but above rivers and terrain.
-var ObjectRunes = map[pb.WorldObject]string{
+var objectRunes = map[pb.WorldObject]string{
 	pb.WorldObject_WORLD_OBJECT_VILLAGE: "⌂", // BMP U+2302 HOUSE
 	pb.WorldObject_WORLD_OBJECT_CASTLE:  "♜", // BMP U+265C BLACK CHESS ROOK
 }
 
-// TerrainRunes maps every wire-level Terrain value to the rune shown for
-// that biome. Missing keys fall back to RuneUnspecified in the renderer.
-var TerrainRunes = map[pb.Terrain]string{
+// terrainRunes maps every wire-level Terrain value to the rune shown for
+// that biome. Missing keys fall back to runeUnspecified in the renderer.
+var terrainRunes = map[pb.Terrain]string{
 	// Grass family: progressively denser vegetation.
 	pb.Terrain_TERRAIN_PLAINS:    "·", // middle dot
 	pb.Terrain_TERRAIN_GRASSLAND: "„", // low double comma

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -13,8 +13,6 @@ var styles = struct {
 	selfPlayer  lipgloss.Style
 	otherPlayer lipgloss.Style
 	river       lipgloss.Style
-	village     lipgloss.Style
-	castle      lipgloss.Style
 	unknownTile lipgloss.Style
 
 	title   lipgloss.Style
@@ -30,8 +28,6 @@ var styles = struct {
 	selfPlayer:  lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true),
 	otherPlayer: lipgloss.NewStyle().Foreground(lipgloss.Color("13")).Bold(true),
 	river:       lipgloss.NewStyle().Foreground(lipgloss.Color("45")),
-	village:     lipgloss.NewStyle().Foreground(lipgloss.Color("208")).Bold(true), // warm orange
-	castle:      lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true), // red
 	unknownTile: lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
 
 	title:  lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12")).Padding(0, 1),
@@ -46,6 +42,13 @@ var styles = struct {
 		BorderForeground(lipgloss.Color("8")).Padding(0, 1),
 	errBox: lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("9")).Foreground(lipgloss.Color("9")).Padding(1, 2),
+}
+
+// objectStyles pairs each wire WorldObject with its foreground style. Edit
+// alongside objectRunes to re-skin village/castle overlays.
+var objectStyles = map[pb.WorldObject]lipgloss.Style{
+	pb.WorldObject_WORLD_OBJECT_VILLAGE: lipgloss.NewStyle().Foreground(lipgloss.Color("208")).Bold(true),
+	pb.WorldObject_WORLD_OBJECT_CASTLE:  lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true),
 }
 
 // terrainStyles pairs each biome with its foreground colour. Edit this
@@ -73,14 +76,14 @@ var terrainStyles = map[pb.Terrain]lipgloss.Style{
 // biome rune with a cyan stroke so water routes stand out against land.
 func lookTile(t *pb.Tile) (string, lipgloss.Style) {
 	if t == nil {
-		return RuneUnspecified, styles.unknownTile
+		return runeUnspecified, styles.unknownTile
 	}
 	if t.GetRiver() {
-		return RiverRune, styles.river
+		return riverRune, styles.river
 	}
-	r, ok := TerrainRunes[t.GetTerrain()]
+	r, ok := terrainRunes[t.GetTerrain()]
 	if !ok {
-		return RuneUnspecified, styles.unknownTile
+		return runeUnspecified, styles.unknownTile
 	}
 	style, ok := terrainStyles[t.GetTerrain()]
 	if !ok {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -13,6 +13,8 @@ var styles = struct {
 	selfPlayer  lipgloss.Style
 	otherPlayer lipgloss.Style
 	river       lipgloss.Style
+	village     lipgloss.Style
+	castle      lipgloss.Style
 	unknownTile lipgloss.Style
 
 	title   lipgloss.Style
@@ -28,6 +30,8 @@ var styles = struct {
 	selfPlayer:  lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true),
 	otherPlayer: lipgloss.NewStyle().Foreground(lipgloss.Color("13")).Bold(true),
 	river:       lipgloss.NewStyle().Foreground(lipgloss.Color("45")),
+	village:     lipgloss.NewStyle().Foreground(lipgloss.Color("208")).Bold(true), // warm orange
+	castle:      lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true), // red
 	unknownTile: lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
 
 	title:  lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12")).Padding(0, 1),

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -10,8 +10,8 @@ import (
 	pb "github.com/Rioverde/gongeons/internal/proto"
 )
 
-// Every glyph this file renders comes from runes.go — RuneSelf / RuneOther /
-// RuneUnspecified / RiverRune / TerrainRunes for the map, plus the
+// Every glyph this file renders comes from runes.go — runeSelf / runeOther /
+// runeUnspecified / riverRune / terrainRunes for the map, plus the
 // chrome constants (InputPrompt, LogBullet, etc.) for the surrounding UI.
 
 // View renders the full screen for the current phase.
@@ -90,7 +90,7 @@ func (m *Model) renderGrid() string {
 		for x := range m.width {
 			idx := y*m.width + x
 			if idx >= len(m.tiles) {
-				b.WriteString(styles.unknownTile.Render(RuneUnspecified))
+				b.WriteString(styles.unknownTile.Render(runeUnspecified))
 				continue
 			}
 			b.WriteString(m.renderCell(m.tiles[idx]))
@@ -107,25 +107,24 @@ func (m *Model) renderGrid() string {
 // other player is decided by myID.
 func (m *Model) renderCell(t *pb.Tile) string {
 	if t == nil {
-		return styles.unknownTile.Render(RuneUnspecified)
+		return styles.unknownTile.Render(runeUnspecified)
 	}
 	if t.GetOccupant() == pb.OccupantKind_OCCUPANT_PLAYER && t.GetEntityId() != "" {
 		if t.GetEntityId() == m.myID {
-			return styles.selfPlayer.Render(RuneSelf)
+			return styles.selfPlayer.Render(runeSelf)
 		}
-		return styles.otherPlayer.Render(RuneOther)
+		return styles.otherPlayer.Render(runeOther)
 	}
 	if obj := t.GetObject(); obj != pb.WorldObject_WORLD_OBJECT_UNSPECIFIED {
-		if glyph, ok := ObjectRunes[obj]; ok {
-			switch obj {
-			case pb.WorldObject_WORLD_OBJECT_VILLAGE:
-				return styles.village.Render(glyph)
-			case pb.WorldObject_WORLD_OBJECT_CASTLE:
-				return styles.castle.Render(glyph)
-			case pb.WorldObject_WORLD_OBJECT_UNSPECIFIED:
-				// unreachable — guarded by outer if
-			}
+		glyph, gOK := objectRunes[obj]
+		style, sOK := objectStyles[obj]
+		if gOK && sOK && glyph != "" {
+			return style.Render(glyph)
 		}
+		// Unknown / version-skew object from the server: render the "what is this"
+		// marker so the player SEES something is there, rather than silently
+		// falling through to the terrain underneath.
+		return styles.unknownTile.Render(runeUnspecified)
 	}
 	r, s := lookTile(t)
 	return s.Render(r)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -102,8 +102,9 @@ func (m *Model) renderGrid() string {
 	return styles.box.Render(b.String())
 }
 
-// renderCell picks the rune + style for one tile. Occupant wins over
-// terrain; self vs other is decided by myID.
+// renderCell picks the rune + style for one tile. Layer precedence:
+// occupant > world-object (village / castle) > river > terrain. Self vs
+// other player is decided by myID.
 func (m *Model) renderCell(t *pb.Tile) string {
 	if t == nil {
 		return styles.unknownTile.Render(RuneUnspecified)
@@ -113,6 +114,18 @@ func (m *Model) renderCell(t *pb.Tile) string {
 			return styles.selfPlayer.Render(RuneSelf)
 		}
 		return styles.otherPlayer.Render(RuneOther)
+	}
+	if obj := t.GetObject(); obj != pb.WorldObject_WORLD_OBJECT_UNSPECIFIED {
+		if glyph, ok := ObjectRunes[obj]; ok {
+			switch obj {
+			case pb.WorldObject_WORLD_OBJECT_VILLAGE:
+				return styles.village.Render(glyph)
+			case pb.WorldObject_WORLD_OBJECT_CASTLE:
+				return styles.castle.Render(glyph)
+			case pb.WorldObject_WORLD_OBJECT_UNSPECIFIED:
+				// unreachable — guarded by outer if
+			}
+		}
 	}
 	r, s := lookTile(t)
 	return s.Render(r)

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1,0 +1,103 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/Rioverde/gongeons/internal/proto"
+)
+
+// TestRenderCellLayerPrecedence exercises the documented rendering layers:
+// occupant > world-object (village / castle) > river > terrain. The table
+// keeps each case self-contained so a regression in one layer doesn't drag
+// the others down with it. Assertions use strings.Contains against the raw
+// output to avoid hand-rolling ANSI-escape comparisons.
+func TestRenderCellLayerPrecedence(t *testing.T) {
+	t.Parallel()
+
+	plainsRune := terrainRunes[pb.Terrain_TERRAIN_PLAINS]
+	villageRune := objectRunes[pb.WorldObject_WORLD_OBJECT_VILLAGE]
+
+	cases := []struct {
+		name        string
+		myID        string
+		tile        *pb.Tile
+		mustHave    []string
+		mustNotHave []string
+	}{
+		{
+			name:        "plain terrain shows terrain rune, not player",
+			tile:        &pb.Tile{Terrain: pb.Terrain_TERRAIN_PLAINS},
+			mustHave:    []string{plainsRune},
+			mustNotHave: []string{runeSelf, runeOther},
+		},
+		{
+			name:        "river overrides terrain",
+			tile:        &pb.Tile{Terrain: pb.Terrain_TERRAIN_PLAINS, River: true},
+			mustHave:    []string{riverRune},
+			mustNotHave: []string{plainsRune},
+		},
+		{
+			name: "village shows over plain terrain",
+			tile: &pb.Tile{
+				Terrain: pb.Terrain_TERRAIN_PLAINS,
+				Object:  pb.WorldObject_WORLD_OBJECT_VILLAGE,
+			},
+			mustHave: []string{villageRune},
+		},
+		{
+			name: "village wins over river",
+			tile: &pb.Tile{
+				Terrain: pb.Terrain_TERRAIN_PLAINS,
+				River:   true,
+				Object:  pb.WorldObject_WORLD_OBJECT_VILLAGE,
+			},
+			mustHave:    []string{villageRune},
+			mustNotHave: []string{riverRune},
+		},
+		{
+			name: "self player wins over village",
+			myID: "me",
+			tile: &pb.Tile{
+				Terrain:  pb.Terrain_TERRAIN_PLAINS,
+				Object:   pb.WorldObject_WORLD_OBJECT_VILLAGE,
+				Occupant: pb.OccupantKind_OCCUPANT_PLAYER,
+				EntityId: "me",
+			},
+			mustHave:    []string{runeSelf},
+			mustNotHave: []string{villageRune, runeOther},
+		},
+		{
+			name: "unknown WorldObject falls back to unspecified rune",
+			tile: &pb.Tile{
+				Terrain: pb.Terrain_TERRAIN_PLAINS,
+				Object:  pb.WorldObject(99),
+			},
+			mustHave:    []string{runeUnspecified},
+			mustNotHave: []string{plainsRune},
+		},
+		{
+			name:     "nil tile renders unspecified rune",
+			tile:     nil,
+			mustHave: []string{runeUnspecified},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := &Model{myID: tc.myID}
+			out := m.renderCell(tc.tile)
+			for _, want := range tc.mustHave {
+				if !strings.Contains(out, want) {
+					t.Errorf("output %q missing expected glyph %q", out, want)
+				}
+			}
+			for _, bad := range tc.mustNotHave {
+				if strings.Contains(out, bad) {
+					t.Errorf("output %q unexpectedly contains glyph %q", out, bad)
+				}
+			}
+		})
+	}
+}

--- a/proto/gongeons.proto
+++ b/proto/gongeons.proto
@@ -51,6 +51,14 @@ enum OccupantKind {
   OCCUPANT_MONSTER     = 2;
 }
 
+// WorldObject is a static structure the procedural generator places on a tile.
+// Rendered below the player glyph but above the terrain.
+enum WorldObject {
+  WORLD_OBJECT_UNSPECIFIED = 0;
+  WORLD_OBJECT_VILLAGE     = 1;
+  WORLD_OBJECT_CASTLE      = 2;
+}
+
 // Tile is an atomic map cell. Used in Snapshot only — Events carry deltas,
 // not full tile replacements.
 message Tile {
@@ -58,6 +66,7 @@ message Tile {
   OccupantKind occupant  = 2;
   string       entity_id = 3; // occupant ID, empty if no occupant
   bool         river     = 4; // set on tiles the generator carved a river on
+  WorldObject  object    = 5; // village / castle overlay
 }
 
 // Entity is a positioned actor in the world. Combat stats / monsters are


### PR DESCRIPTION
## Summary

- Proto: adds \`WorldObject\` enum (\`VILLAGE\`, \`CASTLE\`) and \`Tile.object\` field so the POI generator's output actually reaches the client.
- Server: \`objectToPB\` maps domain \`ObjectKind\` to the wire enum; \`snapshotOf\` fills the new field on every tile.
- Client: \`renderCell\` layers \`player > object > river > terrain\`, with \`lipgloss\` styles for village (orange) and castle (red).
- Rendering: switched the entire terrain vocabulary to a single-cell Unicode set (\`▲\`, \`♣\`, \`≈\`, etc.) centralised in \`internal/ui/runes.go\`. Occupant-overlay runes and UI chrome strings moved into the same file so every glyph on screen has one source of truth.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -race ./...\`
- [x] \`golangci-lint run ./...\` — 0 issues
- [ ] Manual: two clients on the same seed see villages (\`⌂\`) and castles (\`♜\`) at identical coordinates
- [ ] Manual: glyphs render as single cells in iTerm / Terminal.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)